### PR TITLE
fix: correct build output path and add CI/CD for GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,42 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Commit and push docs
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add docs/
+          if git diff --staged --quiet; then
+            echo "No changes to docs/, skipping commit."
+          else
+            git commit -m "chore: rebuild docs [skip ci]"
+            git push
+          fi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conraddiao.github.io",
-  "homepage": "https://conraddiao.github.io",
+  "homepage": "https://econr.ad",
   "version": "0.1.0",
   "private": true,
   "dependencies": {
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "BUILD_PATH=docs react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
- Set BUILD_PATH=docs so npm run build outputs directly to docs/ (previously
  CRA was building to build/ and leaving docs/ stale)
- Update homepage to match the live custom domain (econr.ad)
- Add GitHub Actions workflow to auto-build and commit docs/ on every push
  to main, removing the need for manual rebuilds

https://claude.ai/code/session_01FrKCwuWsjRqTnmrxHVsbJY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project homepage URL to https://econr.ad.
  * Added automated deployment pipeline for code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->