### PR TITLE
Enhance markdown parser to support inline images, videos, and code

### DIFF
--- a/src/Post.css
+++ b/src/Post.css
@@ -97,3 +97,47 @@
   color: darkgray;
   font-size: 2rem;
 }
+
+.post-copy p {
+  margin: 0.5rem 0;
+}
+
+.post-copy img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 4px;
+  margin: 1rem 0;
+}
+
+.post-copy video {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  border-radius: 4px;
+  margin: 1rem 0;
+}
+
+.post-copy code {
+  font-family: 'IBM Plex Mono', monospace;
+  background-color: rgba(255, 255, 255, 0.08);
+  padding: 0.1em 0.35em;
+  border-radius: 3px;
+  font-size: 0.85em;
+}
+
+.post-copy pre {
+  background-color: rgba(255, 255, 255, 0.06);
+  border-left: 3px solid var(--color-accent);
+  padding: 1rem;
+  border-radius: 4px;
+  overflow-x: auto;
+  margin: 1rem 0;
+}
+
+.post-copy pre code {
+  background: none;
+  padding: 0;
+  border-radius: 0;
+  font-size: 0.875em;
+  line-height: 1.6;
+}

--- a/src/Post.jsx
+++ b/src/Post.jsx
@@ -1,18 +1,56 @@
 import React, { useEffect, useRef, useState } from 'react';
 import './Post.css';
 
-// Minimal markdown -> HTML converter to support basic markdown in posts.json (links, newlines, paragraphs)
+// Markdown -> HTML converter supporting links, images, videos, code blocks, inline code, bold, italic
 const markdownToHtml = (md) => {
   if (!md) return '';
+
   const escapeHtml = (s) =>
     s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 
-  let text = escapeHtml(md);
-  // convert markdown links [text](url)
-  text = text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>');
-  // paragraphs (double newline) and single newlines -> <br>
-  text = '<p>' + text.replace(/\n{2,}/g, '</p><p>').replace(/\n/g, '<br>') + '</p>';
-  return text;
+  const isVideoUrl = (url) => /\.(mp4|webm|ogg|mov)(\?.*)?$/i.test(url);
+
+  const processInline = (escaped) => {
+    let t = escaped;
+    // Inline code (backticks)
+    t = t.replace(/`([^`\n]+)`/g, '<code>$1</code>');
+    // Images and videos: ![alt](url)
+    t = t.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (_, alt, url) =>
+      isVideoUrl(url)
+        ? `<video src="${url}" controls playsinline></video>`
+        : `<img src="${url}" alt="${alt}" loading="lazy">`
+    );
+    // Links: [text](url)
+    t = t.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>');
+    // Bold: **text**
+    t = t.replace(/\*\*([^*\n]+)\*\*/g, '<strong>$1</strong>');
+    // Italic: *text*
+    t = t.replace(/\*([^*\n]+)\*/g, '<em>$1</em>');
+    return t;
+  };
+
+  const html = [];
+  // Split out fenced code blocks first so their content is not processed as markdown
+  const parts = md.split(/(```(?:\w+)?\n[\s\S]*?```)/g);
+
+  for (const part of parts) {
+    const codeBlock = part.match(/^```(\w+)?\n([\s\S]*)```$/);
+    if (codeBlock) {
+      const lang = codeBlock[1] || '';
+      const code = escapeHtml(codeBlock[2]);
+      html.push(`<pre><code${lang ? ` class="language-${lang}"` : ''}>${code}</code></pre>`);
+    } else {
+      const paragraphs = part.split(/\n{2,}/);
+      for (const para of paragraphs) {
+        const trimmed = para.trim();
+        if (!trimmed) continue;
+        const content = processInline(escapeHtml(trimmed)).replace(/\n/g, '<br>');
+        html.push(`<p>${content}</p>`);
+      }
+    }
+  }
+
+  return html.join('');
 };
 
 const Post = ({ post }) => {
@@ -141,7 +179,7 @@ const Post = ({ post }) => {
         </>
       )}
 
-      <p dangerouslySetInnerHTML={{ __html: markdownToHtml(post.copy) }} />
+      <div className="post-copy" dangerouslySetInnerHTML={{ __html: markdownToHtml(post.copy) }} />
     </div>
   );
 };


### PR DESCRIPTION
- Fenced code blocks (```lang\n...\n```) render as <pre><code>
- Inline code with backticks renders as <code>
- Images ![alt](url) render as <img> inline in copy text
- Videos ![alt](url.mp4) detected by extension, render as <video>
- Bold **text** and italic *text* support added
- Copy container changed from <p> to <div.post-copy> to allow block elements
- CSS added for inline media, code, and pre blocks

https://claude.ai/code/session_01CR44TrWzdjmpJ5kKx5fJiW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced markdown rendering with support for inline code, images, video embedding, links, bold, and italic text.
  * Improved styling for code blocks with syntax highlighting, left accent border, and scrollable overflow.
  * Better rich-text formatting with responsive image and video sizing, proper spacing, and refined typography.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->