### PR TITLE
Revert GridFeed to single column layout

### DIFF
--- a/src/GridFeed.css
+++ b/src/GridFeed.css
@@ -59,30 +59,6 @@
 
 .grid-feed-grid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: 1fr;
   gap: 1.5rem;
-}
-
-.grid-feed-cell .post {
-  max-width: none;
-}
-
-.grid-feed-cell .post > h3 {
-  font-size: 1rem;
-  margin-top: 0.75rem;
-  margin-bottom: 0.5rem;
-}
-
-.grid-feed-cell .post > p {
-  font-size: 0.85rem;
-}
-
-.grid-feed-cell .container {
-  aspect-ratio: 1;
-}
-
-@media screen and (max-width: 600px) {
-  .grid-feed-grid {
-    grid-template-columns: 1fr;
-  }
 }


### PR DESCRIPTION
Remove 2-column grid, associated cell style overrides, and mobile breakpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the grid feed layout to display content in a single column instead of multiple columns
  * Simplified post card styling and removed fixed aspect ratio constraints
  * Removed responsive layout adjustments for smaller screen sizes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->