### PR TITLE
Shadcn-style badges and header layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -115,6 +115,22 @@ hr {
   max-height: 300px;
 }
 
+.header-subheader {
+  display: flex;
+  gap: 1.5rem;
+  align-items: flex-start;
+}
+
+.header-subheader > p {
+  flex: 1;
+  min-width: 0;
+}
+
+.header-subheader > .grid-feed-filters {
+  flex-shrink: 0;
+  align-content: flex-start;
+}
+
 .posts {
   padding: 0.5rem;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useMemo } from 'react';
 import { Analytics } from '@vercel/analytics/react';
 import Header from './Header.jsx';
 import Footer from './Footer.jsx';
@@ -9,10 +9,30 @@ import honorifics from './honorifics.json';
 import './App.css';
 
 function App() {
+  const [activeTag, setActiveTag] = useState(null);
+
+  const allTags = useMemo(() => {
+    const tagSet = new Set();
+    posts.forEach(post => {
+      (post.tags || []).forEach(tag => tagSet.add(tag));
+    });
+    return Array.from(tagSet);
+  }, []);
+
+  const filteredPosts = activeTag
+    ? posts.filter(post => (post.tags || []).includes(activeTag))
+    : posts;
+
   return (
     <div className="App">
-      <Header id="header" honorifics={honorifics} />
-      <GridFeed posts={posts} />
+      <Header
+        id="header"
+        honorifics={honorifics}
+        allTags={allTags}
+        activeTag={activeTag}
+        setActiveTag={setActiveTag}
+      />
+      <GridFeed posts={filteredPosts} />
       <Footer />
       <Analytics />
     </div>

--- a/src/GridFeed.css
+++ b/src/GridFeed.css
@@ -10,31 +10,35 @@
 }
 
 .grid-feed-filters {
-  display: flex;
-  gap: 0.5rem;
+  display: none;
+  gap: 0.4rem;
   flex-wrap: wrap;
-  margin: 1.5rem 0 1rem;
+  justify-content: flex-end;
+  margin: 0.75rem 0 0.25rem;
 }
 
 .grid-feed-tag {
   font-family: var(--font-body);
-  font-size: 0.85rem;
+  font-size: 0.75rem;
   background: transparent;
   color: var(--color-text);
-  border: 1px solid var(--color-muted);
-  padding: 0.3rem 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  padding: 0.2rem 0.6rem;
+  border-radius: 9999px;
   cursor: pointer;
-  transition: background-color 0.2s, border-color 0.2s;
+  transition: background-color 0.2s, border-color 0.2s, color 0.2s;
+  line-height: 1.4;
 }
 
 .grid-feed-tag:hover {
-  border-color: var(--color-accent);
+  border-color: rgba(255, 255, 255, 0.5);
+  background: rgba(255, 255, 255, 0.05);
 }
 
 .grid-feed-tag.active {
   background-color: var(--color-accent);
   border-color: var(--color-accent);
-  color: var(--color-bg);
+  color: #fff;
 }
 
 .timeline {
@@ -68,12 +72,6 @@
   background: var(--timeline-line-color);
 }
 
-.timeline-entry:last-child .timeline-rail::before {
-  bottom: auto;
-  height: calc(var(--timeline-sticky-top) - 2.75rem);
-  min-height: 2rem;
-}
-
 .timeline-marker {
   position: sticky;
   top: var(--timeline-sticky-top);
@@ -81,7 +79,7 @@
   display: inline-flex;
   align-items: center;
   gap: 0.75rem;
-  padding: 0.75rem 0 var(--timeline-line-gap);
+  padding: 0.5rem 0;
   background: var(--color-bg);
 }
 
@@ -107,22 +105,37 @@
   line-height: 1;
 }
 
+.timeline-title-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-top: 0;
+}
+
+.timeline-title-row h3 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  font-size: inherit;
+  white-space: nowrap;
+}
+
 .timeline-post-tags {
   display: flex;
-  gap: 0.4rem;
+  gap: 0.25rem;
   flex-wrap: wrap;
-  min-height: 1.35rem;
-  margin-bottom: 0.5rem;
 }
 
 .timeline-tag-badge {
-  font-size: 0.7rem;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  padding: 0.15rem 0.5rem;
-  border: 1px solid var(--color-muted);
+  font-family: var(--font-body);
+  font-size: 0.75rem;
+  background: transparent;
   color: var(--color-text);
-  border-radius: 2px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  padding: 0.2rem 0.6rem;
+  border-radius: 9999px;
+  line-height: 1.4;
+  white-space: nowrap;
 }
 
 .timeline-content .post {
@@ -146,5 +159,10 @@
 
   .timeline-date {
     font-size: 0.75rem;
+  }
+
+  .timeline-tag-badge {
+    font-size: 0.65rem;
+    padding: 0.15rem 0.45rem;
   }
 }

--- a/src/GridFeed.jsx
+++ b/src/GridFeed.jsx
@@ -1,44 +1,12 @@
-import React, { useState, useMemo } from 'react';
+import React from 'react';
 import Post from './Post';
 import './GridFeed.css';
 
 const GridFeed = ({ posts }) => {
-  const [activeTag, setActiveTag] = useState(null);
-
-  const allTags = useMemo(() => {
-    const tagSet = new Set();
-    posts.forEach(post => {
-      (post.tags || []).forEach(tag => tagSet.add(tag));
-    });
-    return Array.from(tagSet);
-  }, [posts]);
-
-  const filteredPosts = activeTag
-    ? posts.filter(post => (post.tags || []).includes(activeTag))
-    : posts;
-
   return (
     <div className="grid-feed">
-      <div className="grid-feed-filters">
-        <button
-          className={`grid-feed-tag ${activeTag === null ? 'active' : ''}`}
-          onClick={() => setActiveTag(null)}
-        >
-          all
-        </button>
-        {allTags.map(tag => (
-          <button
-            key={tag}
-            className={`grid-feed-tag ${activeTag === tag ? 'active' : ''}`}
-            onClick={() => setActiveTag(tag)}
-          >
-            {tag}
-          </button>
-        ))}
-      </div>
-
       <div className="timeline">
-        {filteredPosts.map((post) => (
+        {posts.map((post) => (
           <div className="timeline-entry" key={post.title}>
             <div className="timeline-rail">
               <div className="timeline-marker">
@@ -47,12 +15,15 @@ const GridFeed = ({ posts }) => {
               </div>
             </div>
             <div className="timeline-content">
-              <div className="timeline-post-tags">
-                {(post.tags || []).map(tag => (
-                  <span className="timeline-tag-badge" key={tag}>{tag}</span>
-                ))}
+              <div className="timeline-title-row">
+                <h3>{post.title}</h3>
+                <div className="timeline-post-tags">
+                  {(post.tags || []).map(tag => (
+                    <span className="timeline-tag-badge" key={tag}>{tag}</span>
+                  ))}
+                </div>
               </div>
-              <Post post={post} showYear={false} />
+              <Post post={post} showYear={false} showTitle={false} />
             </div>
           </div>
         ))}

--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -9,7 +9,7 @@ import Honorific from './Honorific';
 // import { headerHeight, setHeaderHeight } from './App';
 import { useRef } from 'react';
 
-const Header = ({ honorifics }) => {
+const Header = ({ honorifics, allTags = [], activeTag, setActiveTag }) => {
   const [isCollapsed, setIsCollapsed] = useState(false);
   const headerRef = useRef(null);
 
@@ -41,34 +41,53 @@ const Header = ({ honorifics }) => {
     className="header" id="header">
       <h1 id="header-title" className='display-flex'>
         <span> <a href="#">~&nbsp;hi,</a></span>
-        <span> I'm </span>
+        <span>&nbsp;I'm&nbsp;</span>
         <span><a href="#">@conraddiao</a></span>
         <span>,&nbsp;</span>
         <span>the&nbsp;</span>
         <span><Honorific honorifics={honorifics} /></span>
         <span>.&nbsp;~</span>
       </h1>
-      <p className={`slider ${isCollapsed ? 'closed' : 'open'}`}>
-        Product Manager with Full-stack Operations, Growth, and Design background.
-        <br />
-        <br />
-        Product @ <a href="https://www.getonecrew.com/">OneCrew</a>.
-        <br />
-        Product @ <a href="https://www.fiercehealthcare.com/health-tech/primary-care-player-forward-shutters-after-raising-400m-rolling-out-carepods">Forward</a>.
-        <br />
-        Strategy & Ops @ <a href="https://www.salesforce.com/">Salesforce</a>.
-        <br />
-        SWE Intern @ <a href="https://numie.co/">Numie</a>, <a href="https://poshly.com">Poshly</a>, and <a href="https://qb3.org/">QB3</a>.
-        <br />
-        <br />
-        B.S. Architecture @ <a href="https://taubmancollege.umich.edu/">Michigan</a>.
-        <br />
-        <br />
-        Find me on&nbsp;
-        <a href="https://www.linkedin.com/in/conraddiao/"><FontAwesomeIcon icon={faLinkedin} size="1x" /></a>,&nbsp;
-        <a href="https://www.instagram.com/conraddiao/"><FontAwesomeIcon icon={faInstagramSquare} size="1x" /></a>,&nbsp;
-        <a href="https://github.com/conraddiao/"><FontAwesomeIcon icon={faGithub} size="1x" /></a>.
-      </p>
+      <div className={`slider header-subheader ${isCollapsed ? 'closed' : 'open'}`}>
+        <p>
+          Product Manager with Full-stack Operations, Growth, and Design background.
+          <br />
+          <br />
+          Head of Product @ <a href="https://www.getonecrew.com/">OneCrew</a>.
+          <br />
+          <em>prev. </em>Product @ <a href="https://www.fiercehealthcare.com/health-tech/primary-care-player-forward-shutters-after-raising-400m-rolling-out-carepods">Forward</a>.
+          <br />
+          <em>prev. </em>Strategy & Ops @ <a href="https://www.salesforce.com/">Salesforce</a>.
+          <br />
+          <em>prev. </em>SWE Intern @ <a href="https://numie.co/">Numie</a>, <a href="https://poshly.com">Poshly</a>, and <a href="https://qb3.org/">QB3</a>.
+          <br />
+          <br />
+          B.S. Architecture @ <a href="https://taubmancollege.umich.edu/">Michigan</a>.
+          <br />
+          <br />
+          Find me on&nbsp;
+          <a href="https://www.linkedin.com/in/conraddiao/"><FontAwesomeIcon icon={faLinkedin} size="1x" /></a>,&nbsp;
+          <a href="https://www.instagram.com/conraddiao/"><FontAwesomeIcon icon={faInstagramSquare} size="1x" /></a>,&nbsp;
+          <a href="https://github.com/conraddiao/"><FontAwesomeIcon icon={faGithub} size="1x" /></a>.
+        </p>
+        <div className="grid-feed-filters">
+          <button
+            className={`grid-feed-tag ${activeTag === null ? 'active' : ''}`}
+            onClick={() => setActiveTag(null)}
+          >
+            all
+          </button>
+          {allTags.map(tag => (
+            <button
+              key={tag}
+              className={`grid-feed-tag ${activeTag === tag ? 'active' : ''}`}
+              onClick={() => setActiveTag(tag)}
+            >
+              {tag}
+            </button>
+          ))}
+        </div>
+      </div>
       <hr />
     </header>
   );

--- a/src/Post.jsx
+++ b/src/Post.jsx
@@ -53,7 +53,7 @@ const markdownToHtml = (md) => {
   return html.join('');
 };
 
-const Post = ({ post, showYear = true }) => {
+const Post = ({ post, showYear = true, showTitle = true }) => {
   const containerRef = useRef(null);
   const paginationRef = useRef(null);
   const postRef = useRef(null);
@@ -131,10 +131,12 @@ const Post = ({ post, showYear = true }) => {
 
   return (
     <div className="post" id={`p-${post.id}`} ref={postRef}>
-      <h3>
-        {post.title}
-        {showYear && <> , <span className="postDate">{post.year}.</span></>}
-      </h3>
+      {showTitle && (
+        <h3>
+          {post.title}
+          {showYear && <> , <span className="postDate">{post.year}.</span></>}
+        </h3>
+      )}
 
       {post.images && post.images.length > 0 && (
         <>


### PR DESCRIPTION
## Summary
- Restyle filters and post labels as shadcn-style rounded pill badges
- Move filter controls into the collapsing header (hidden for now)
- Move post tag labels inline with title row, right-aligned
- Add italic "prev." prefix to prior job roles in header bio
- Flex layout for header subheader: bio left, filters right

## Test plan
- [ ] Verify badges render as rounded pills with outline style
- [ ] Verify labels appear right-aligned on the title row
- [ ] Verify header collapses/expands correctly on scroll
- [ ] Verify responsive layout on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tag-based filtering: users can now select tags from the header to filter and view specific posts
  * Introduced "all posts" option to clear tag filters

* **Style**
  * Redesigned tag badges with modern pill-shaped styling and semi-transparent borders
  * Improved header layout with enhanced spacing and visual hierarchy
  * Updated role descriptions in header profile

<!-- end of auto-generated comment: release notes by coderabbit.ai -->