### PR TITLE
Use measured header height and pause honorific on collapse

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15635,6 +15635,20 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",

--- a/src/GridFeed.css
+++ b/src/GridFeed.css
@@ -5,7 +5,7 @@
   --timeline-pip-size: 10px;
   --timeline-line-width: 2px;
   --timeline-line-color: rgba(255, 255, 255, 0.3);
-  --timeline-sticky-top: 5rem;
+  --timeline-sticky-top: var(--header-height, 5rem);
   --timeline-line-gap: 0.45rem;
 }
 
@@ -74,7 +74,7 @@
 
 .timeline-marker {
   position: sticky;
-  top: var(--timeline-sticky-top);
+  top: calc(var(--timeline-sticky-top) + 1rem);
   z-index: 1;
   display: inline-flex;
   align-items: center;
@@ -138,6 +138,10 @@
   white-space: nowrap;
 }
 
+.timeline-content {
+  padding-top: .25rem;
+}
+
 .timeline-content .post {
   max-width: none;
 }
@@ -150,7 +154,7 @@
   .grid-feed {
     --timeline-rail-width: 4.25rem;
     --timeline-gap: 0.9rem;
-    --timeline-sticky-top: 3.9rem;
+    --timeline-sticky-top: var(--header-height, 3.9rem);
   }
 
   .timeline-marker {

--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -35,6 +35,21 @@ const Header = ({ honorifics, allTags = [], activeTag, setActiveTag }) => {
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
+  useEffect(() => {
+    const el = headerRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver(([entry]) => {
+      const headerHeight = `${entry.contentRect.height}px`;
+      document.documentElement.style.setProperty(
+        '--header-height',
+        headerHeight
+      );
+      console.log('header-height:', headerHeight);
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
   return (
     <header
     ref={headerRef}
@@ -45,7 +60,7 @@ const Header = ({ honorifics, allTags = [], activeTag, setActiveTag }) => {
         <span><a href="#">@conraddiao</a></span>
         <span>,&nbsp;</span>
         <span>the&nbsp;</span>
-        <span><Honorific honorifics={honorifics} /></span>
+        <span><Honorific honorifics={honorifics} forcePaused={isCollapsed} /></span>
         <span>.&nbsp;~</span>
       </h1>
       <div className={`slider header-subheader ${isCollapsed ? 'closed' : 'open'}`}>

--- a/src/Header.test.jsx
+++ b/src/Header.test.jsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import Header from './Header';
+
+jest.mock('./Honorific', () => function HonorificMock({ forcePaused }) {
+  return (
+    <span data-testid="honorific-state">
+      {forcePaused ? 'paused' : 'running'}
+    </span>
+  );
+});
+
+describe('Header', () => {
+  let rafId;
+  let rafCallbacks;
+
+  beforeEach(() => {
+    rafId = 1;
+    rafCallbacks = new Map();
+
+    Object.defineProperty(window, 'scrollY', {
+      value: 0,
+      writable: true,
+      configurable: true,
+    });
+
+    class ResizeObserverMock {
+      observe() {}
+
+      disconnect() {}
+    }
+
+    window.ResizeObserver = ResizeObserverMock;
+
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => {
+      const id = rafId++;
+      rafCallbacks.set(id, cb);
+      return id;
+    });
+
+    jest.spyOn(window, 'cancelAnimationFrame').mockImplementation(id => {
+      rafCallbacks.delete(id);
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('pauses honorific while header is collapsed and resumes at top', () => {
+    const runFrame = now => {
+      const pending = Array.from(rafCallbacks.entries());
+      rafCallbacks.clear();
+      pending.forEach(([, cb]) => cb(now));
+    };
+
+    render(
+      <Header
+        honorifics={[{ title: 'product_guy', color: '#EC5829' }]}
+        allTags={[]}
+        activeTag={null}
+        setActiveTag={() => {}}
+      />
+    );
+
+    expect(screen.getByTestId('honorific-state')).toHaveTextContent('running');
+
+    act(() => {
+      window.scrollY = 120;
+      window.dispatchEvent(new Event('scroll'));
+      runFrame(0);
+    });
+
+    expect(screen.getByTestId('honorific-state')).toHaveTextContent('paused');
+
+    act(() => {
+      window.scrollY = 0;
+      window.dispatchEvent(new Event('scroll'));
+      runFrame(16);
+    });
+
+    expect(screen.getByTestId('honorific-state')).toHaveTextContent('running');
+  });
+});

--- a/src/Honorific.jsx
+++ b/src/Honorific.jsx
@@ -1,10 +1,28 @@
 import React, { useEffect, useState, useRef } from 'react';
-const Honorific = ({ honorifics }) => {
-  const [title, setTitle] = useState('');
-  const [bgColor, setBgColor] = useState('');
-  const [paused, setPaused] = useState(false);
+
+const getDefaultHonorific = honorifics => {
+  if (!honorifics || !honorifics.length) {
+    return { title: '', color: '' };
+  }
+
+  const productGuy = honorifics.find(h => h.title === 'product_guy');
+  return productGuy || honorifics[0];
+};
+
+const Honorific = ({ honorifics, forcePaused = false }) => {
+  const initialHonorific = getDefaultHonorific(honorifics);
+  const pausedHonorific = {
+    title: 'product_guy',
+    color: initialHonorific.color || '#EC5829',
+  };
+  const [title, setTitle] = useState(initialHonorific.title);
+  const [bgColor, setBgColor] = useState(initialHonorific.color);
+  const [manualPaused, setManualPaused] = useState(false);
   const rafRef = useRef();
   const lastTimeRef = useRef(performance.now());
+  const paused = forcePaused || manualPaused;
+  const displayTitle = paused ? pausedHonorific.title : title;
+  const displayBgColor = paused ? pausedHonorific.color : bgColor;
 
   useEffect(() => {
     function tick(now) {
@@ -21,12 +39,12 @@ const Honorific = ({ honorifics }) => {
     return () => cancelAnimationFrame(rafRef.current);
   }, [honorifics, paused]);
 
-  const handleClick = () => setPaused(p => !p);
+  const handleClick = () => setManualPaused(p => !p);
 
   return (
     <span
       style={{
-        backgroundColor: bgColor,
+        backgroundColor: displayBgColor,
         fontFamily: "'IBM Plex Mono', monospace",
         fontStyle: 'normal',
         fontWeight: 200,
@@ -36,7 +54,7 @@ const Honorific = ({ honorifics }) => {
       onClick={handleClick}
       title={paused ? 'Click to resume' : 'Click to pause'}
     >
-      &nbsp;{title}&nbsp;
+      &nbsp;{displayTitle}&nbsp;
     </span>
   );
 };

--- a/src/Honorific.test.jsx
+++ b/src/Honorific.test.jsx
@@ -1,0 +1,151 @@
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import Honorific from './Honorific';
+
+const installRafMock = () => {
+  let rafId = 1;
+  const callbacks = new Map();
+
+  jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => {
+    const id = rafId++;
+    callbacks.set(id, cb);
+    return id;
+  });
+
+  jest.spyOn(window, 'cancelAnimationFrame').mockImplementation(id => {
+    callbacks.delete(id);
+  });
+
+  return time => {
+    const pending = Array.from(callbacks.entries());
+    callbacks.clear();
+    pending.forEach(([, cb]) => cb(time));
+  };
+};
+
+describe('Honorific', () => {
+  beforeEach(() => {
+    jest.spyOn(performance, 'now').mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('renders product_guy initially when present', () => {
+    render(
+      <Honorific
+        honorifics={[
+          { title: 'operator', color: 'mediumblue' },
+          { title: 'product_guy', color: '#EC5829' },
+          { title: 'architect', color: 'dimgray' },
+        ]}
+      />
+    );
+
+    expect(screen.getByText(/product_guy/)).toBeInTheDocument();
+  });
+
+  test('falls back to first honorific when product_guy is missing', () => {
+    render(
+      <Honorific
+        honorifics={[
+          { title: 'first_choice', color: 'orchid' },
+          { title: 'second_choice', color: 'seagreen' },
+        ]}
+      />
+    );
+
+    expect(screen.getByText(/first_choice/)).toBeInTheDocument();
+  });
+
+  test('does not cycle while forcePaused is true', () => {
+    const runFrame = installRafMock();
+    jest.spyOn(Math, 'random').mockReturnValue(0.99);
+
+    render(
+      <Honorific
+        honorifics={[
+          { title: 'product_guy', color: '#EC5829' },
+          { title: 'architect', color: 'dimgray' },
+        ]}
+        forcePaused
+      />
+    );
+
+    act(() => {
+      runFrame(250);
+      runFrame(500);
+      runFrame(750);
+    });
+
+    expect(screen.getByText(/product_guy/)).toBeInTheDocument();
+    expect(screen.queryByText(/architect/)).not.toBeInTheDocument();
+  });
+
+  test('cycles while forcePaused is false', () => {
+    const runFrame = installRafMock();
+    jest.spyOn(Math, 'random').mockReturnValue(0.99);
+
+    render(
+      <Honorific
+        honorifics={[
+          { title: 'product_guy', color: '#EC5829' },
+          { title: 'architect', color: 'dimgray' },
+        ]}
+        forcePaused={false}
+      />
+    );
+
+    act(() => {
+      runFrame(250);
+    });
+
+    expect(screen.getByText(/architect/)).toBeInTheDocument();
+  });
+
+  test('manual pause persists across forcePaused true to false transition', () => {
+    const runFrame = installRafMock();
+    jest.spyOn(Math, 'random').mockReturnValue(0.99);
+
+    const { rerender } = render(
+      <Honorific
+        honorifics={[
+          { title: 'product_guy', color: '#EC5829' },
+          { title: 'architect', color: 'dimgray' },
+        ]}
+        forcePaused={false}
+      />
+    );
+
+    fireEvent.click(screen.getByText(/product_guy/));
+
+    rerender(
+      <Honorific
+        honorifics={[
+          { title: 'product_guy', color: '#EC5829' },
+          { title: 'architect', color: 'dimgray' },
+        ]}
+        forcePaused
+      />
+    );
+
+    rerender(
+      <Honorific
+        honorifics={[
+          { title: 'product_guy', color: '#EC5829' },
+          { title: 'architect', color: 'dimgray' },
+        ]}
+        forcePaused={false}
+      />
+    );
+
+    act(() => {
+      runFrame(250);
+      runFrame(500);
+    });
+
+    expect(screen.getByText(/product_guy/)).toBeInTheDocument();
+    expect(screen.queryByText(/architect/)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- replace magic sticky top values with `--header-height` measured from the real header via `ResizeObserver`
- make `Honorific` accept `forcePaused` from header collapse state
- default honorific to `product_guy` and show `product_guy` whenever paused
- add unit/integration tests for honorific pause behavior and header collapse wiring

## Testing
- `CI=true npm test -- --watchAll=false`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Timeline positioning now dynamically adapts to header height for improved responsive layout.
  * Honorific component intelligently pauses when the header collapses during scrolling.
  * Enhanced default honorific selection logic with improved fallback behavior.

* **Tests**
  * Added comprehensive test suites for header and honorific component behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->