### PR TITLE
Add Bubbles project to posts gallery

### DIFF
--- a/src/posts.json
+++ b/src/posts.json
@@ -1,5 +1,13 @@
 [
     {
+        "title": "Bubbles",
+        "year": "2026",
+        "type": "gallery",
+        "tags": ["product"],
+        "copy": "Stop swapping numbers around the table. [Bubbles](https://bubbles.fyi) is a shareable contact list for events and group gatherings — one link to collect everyone, export as vCards when you're done.",
+        "images": []
+    },
+    {
         "title": "Preresign (in-progress)",
         "year": "2025",
         "type": "gallery",


### PR DESCRIPTION
## Summary
Added a new project entry for "Bubbles" to the posts collection, positioning it as the featured/latest project in the gallery.

## Changes
- Added new post entry for Bubbles (2026) as a gallery-type project
- Includes project metadata: title, year, type, tags, and description
- Project is a shareable contact list tool for events and group gatherings
- Positioned at the top of the posts list to appear first in the gallery

## Details
The Bubbles project entry includes:
- **Type**: Gallery project
- **Tags**: product
- **Description**: Highlights the core functionality of collecting contacts via a shareable link with vCard export capability
- **Link**: References https://bubbles.fyi
- **Images**: Empty array (to be populated later)

https://claude.ai/code/session_01PCJzcYKUt6G2hAD21LgFLY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Content**
  * Added new "Bubbles" gallery to the collection with promotional material and resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->