### PR TITLE
Refactor timeline layout: move year to title and reduce rail width

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -18,6 +18,9 @@ html, body {
   -moz-osx-font-smoothing: grayscale;
   margin-top: 0rem;
   scroll-behavior: smooth;
+  width: 100%;
+  max-width: 100%;
+  overflow-x: clip;
 }
 
 * {

--- a/src/GridFeed.css
+++ b/src/GridFeed.css
@@ -1,6 +1,6 @@
 .grid-feed {
   padding: 0.5rem;
-  --timeline-rail-width: 5rem;
+  --timeline-rail-width: 1.5rem;
   --timeline-gap: 1.25rem;
   --timeline-pip-size: 10px;
   --timeline-line-width: 2px;
@@ -96,15 +96,6 @@
   min-width: 0;
 }
 
-.timeline-date {
-  font-family: var(--font-heading);
-  font-size: 0.85rem;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  color: var(--color-text);
-  line-height: 1;
-}
-
 .timeline-title-row {
   display: flex;
   align-items: baseline;
@@ -117,6 +108,12 @@
   margin-top: 0;
   margin-bottom: 1rem;
   font-size: inherit;
+  min-width: 0;
+}
+
+.timeline-year {
+  font-style: italic;
+  color: var(--color-text);
   white-space: nowrap;
 }
 
@@ -152,17 +149,10 @@
 
 @media screen and (max-width: 640px) {
   .grid-feed {
-    --timeline-rail-width: 4.25rem;
+    --timeline-rail-width: 1.25rem;
     --timeline-gap: 0.9rem;
     --timeline-sticky-top: var(--header-height, 3.9rem);
-  }
-
-  .timeline-marker {
-    gap: 0.55rem;
-  }
-
-  .timeline-date {
-    font-size: 0.75rem;
+    padding-right: 1rem;
   }
 
   .timeline-tag-badge {

--- a/src/GridFeed.jsx
+++ b/src/GridFeed.jsx
@@ -11,12 +11,14 @@ const GridFeed = ({ posts }) => {
             <div className="timeline-rail">
               <div className="timeline-marker">
                 <div className="timeline-pip" />
-                <div className="timeline-date">{post.year}</div>
               </div>
             </div>
             <div className="timeline-content">
               <div className="timeline-title-row">
-                <h3>{post.title}</h3>
+                <h3>
+                  {post.title}
+                  <span className="timeline-year">, {post.year}</span>
+                </h3>
                 <div className="timeline-post-tags">
                   {(post.tags || []).map(tag => (
                     <span className="timeline-tag-badge" key={tag}>{tag}</span>


### PR DESCRIPTION
## Summary
This PR refactors the timeline feed layout to improve visual hierarchy and spacing. The year is now displayed inline with the post title instead of as a separate element in the timeline rail, and the timeline rail width has been significantly reduced.

## Key Changes
- **Timeline year repositioning**: Moved the year from a separate `.timeline-date` element in the timeline rail to an inline `.timeline-year` span within the post title, styled in italics
- **Reduced timeline rail width**: Decreased `--timeline-rail-width` from 5rem to 1.5rem on desktop and from 4.25rem to 1.25rem on mobile, creating a more compact timeline
- **Removed timeline-date styles**: Eliminated the dedicated `.timeline-date` class and its associated typography styles (font-family, font-size, text-transform, letter-spacing)
- **Updated timeline-title styling**: Added `min-width: 0` to `.timeline-title` to prevent flex overflow issues
- **Added timeline-year styles**: New `.timeline-year` class with italic styling and nowrap behavior for consistent year display
- **Improved mobile responsiveness**: Simplified mobile media query by removing marker-specific gap adjustment and date font-size override; added `padding-right: 1rem` to grid-feed
- **Fixed horizontal overflow**: Added `width: 100%`, `max-width: 100%`, and `overflow-x: clip` to html/body in App.css to prevent horizontal scrolling

## Implementation Details
The year is now semantically part of the title element, improving the document structure while maintaining visual separation through italic styling. The reduced rail width creates a cleaner, more modern timeline appearance without sacrificing readability.

https://claude.ai/code/session_019i2RPGSSxQnmx8sVgUBiEK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive layout behavior to prevent horizontal overflow.
  * Reduced timeline rail width across desktop and mobile views.
  * Refined timeline heading spacing, sizing, colors, and mobile padding.
  * Displayed each post’s year inline with its title for a more compact timeline presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->